### PR TITLE
Input charlimit option

### DIFF
--- a/input/options.go
+++ b/input/options.go
@@ -73,3 +73,9 @@ func WithWidth(width int) Option {
 		m.textInput.Width = width
 	}
 }
+
+func WithCharLimit(limit int) Option {
+	return func(m *Model) {
+		m.textInput.CharLimit = limit
+	}
+}

--- a/input/options_test.go
+++ b/input/options_test.go
@@ -80,7 +80,6 @@ func TestDefaultValueWithValidateFunc(t *testing.T) {
 }
 
 func TestWithCharLimit(t *testing.T) {
-	// Initialize input and output buffers
 	var in bytes.Buffer
 	var out bytes.Buffer
 
@@ -88,21 +87,17 @@ func TestWithCharLimit(t *testing.T) {
 
 	in.Write(inputString)
 
-	// Create a new model with a custom char limit using WithCharLimit
 	model := input.New(
 		"test",
 		input.WithCharLimit(400),
 	)
 
-	// Run the model using tea program
 	tm, err := tea.NewProgram(model, tea.WithInput(&in), tea.WithOutput(&out)).Run()
 	require.Nil(t, err)
 
-	// Retrieve the final model after running the tea program
 	m, ok := tm.(input.Model)
 	require.True(t, ok)
 
-	// Check if the CharLimit is correctly set
 	require.Equal(t, 400, len(m.Data()))
 }
 

--- a/input/options_test.go
+++ b/input/options_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"reflect"
+	"strings"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -76,4 +77,52 @@ func TestDefaultValueWithValidateFunc(t *testing.T) {
 	require.True(t, ok)
 
 	require.Nil(t, m.Error())
+}
+
+func TestWithCharLimit(t *testing.T) {
+	// Initialize input and output buffers
+	var in bytes.Buffer
+	var out bytes.Buffer
+
+	inputString := []byte(strings.Repeat("a", 400) + "\r\n")
+
+	in.Write(inputString)
+
+	// Create a new model with a custom char limit using WithCharLimit
+	model := input.New(
+		"test",
+		input.WithCharLimit(400),
+	)
+
+	// Run the model using tea program
+	tm, err := tea.NewProgram(model, tea.WithInput(&in), tea.WithOutput(&out)).Run()
+	require.Nil(t, err)
+
+	// Retrieve the final model after running the tea program
+	m, ok := tm.(input.Model)
+	require.True(t, ok)
+
+	// Check if the CharLimit is correctly set
+	require.Equal(t, 400, len(m.Data()))
+}
+
+func TestWithSmallCharLimitError(t *testing.T) {
+	var in bytes.Buffer
+	var out bytes.Buffer
+
+	inputString := []byte(strings.Repeat("a", 50) + "\r\n")
+	in.Write(inputString)
+
+	model := input.New(
+		"test",
+		input.WithCharLimit(10),
+	)
+
+	tm, err := tea.NewProgram(model, tea.WithInput(&in), tea.WithOutput(&out)).Run()
+	require.Nil(t, err)
+
+	m, ok := tm.(input.Model)
+	require.True(t, ok)
+
+	require.Equal(t, 10, len(m.Data()))
 }


### PR DESCRIPTION
This PR introduces a new feature to the input model, allowing users to specify a character limit for input fields. The new functionality is implemented via the `WithCharLimit` option, providing flexibility and control over the length of input in prompts.