### PR TITLE
feat: Add ChooseIndex, AdvancedChooseIndex, and MultiChooseIndex.

### DIFF
--- a/_examples/advancedchoose/main.go
+++ b/_examples/advancedchoose/main.go
@@ -30,6 +30,14 @@ func main() {
 	CheckErr(err)
 
 	val2, err := prompt.New().Ask("Choose:").
+		AdvancedChooseIndex([]choose.Choice{
+			{Text: "Item 1", Note: "The note for item 1"},
+			{Text: "Another item", Note: "The note for item 2"},
+			{Text: "Item 3", Note: "The note for item 3"},
+		})
+	CheckErr(err)
+
+	val3, err := prompt.New().Ask("Choose:").
 		AdvancedChoose(
 			[]choose.Choice{
 				{Text: "Item 1", Note: "The note for item 1"},
@@ -40,5 +48,5 @@ func main() {
 		)
 	CheckErr(err)
 
-	fmt.Printf("{ %s }, { %s }\n", val1, val2)
+	fmt.Printf("{ %s }, { %d }, { %s }\n", val1, val2, val3)
 }

--- a/_examples/choose/main.go
+++ b/_examples/choose/main.go
@@ -25,7 +25,11 @@ func main() {
 		Choose([]string{"Item 1", "Item 2", "Item 3"})
 	CheckErr(err)
 
-	val2, err := prompt.New().Ask("Choose with Help:").
+	val2, err := prompt.New().Ask("Choose:").
+		ChooseIndex([]string{"Item 1", "Item 2", "Item 3"})
+	CheckErr(err)
+
+	val3, err := prompt.New().Ask("Choose with Help:").
 		Choose(
 			[]string{"Item 1", "Item 2", "Item 3"},
 			choose.WithDefaultIndex(1),
@@ -33,5 +37,5 @@ func main() {
 		)
 	CheckErr(err)
 
-	fmt.Printf("{ %s }, { %s }\n", val1, val2)
+	fmt.Printf("{ %s }, { %d }, { %s }\n", val1, val2, val3)
 }

--- a/_examples/multichoose/main.go
+++ b/_examples/multichoose/main.go
@@ -26,7 +26,11 @@ func main() {
 		MultiChoose([]string{"Item 1", "Item 2", "Item 3"})
 	CheckErr(err)
 
-	val2, err := prompt.New().Ask("MultiChoose with Help:").
+	val2, err := prompt.New().Ask("MultiChoose:").
+		MultiChooseIndex([]string{"Item 1", "Item 2", "Item 3"})
+	CheckErr(err)
+
+	val3, err := prompt.New().Ask("MultiChoose with Help:").
 		MultiChoose(
 			[]string{"Item 1", "Item 2", "Item 3"},
 			multichoose.WithDefaultIndexes(1, []int{1, 2}),
@@ -34,5 +38,5 @@ func main() {
 		)
 	CheckErr(err)
 
-	fmt.Printf("{ %s }, { %s }\n", strings.Join(val1, ", "), strings.Join(val2, ", "))
+	fmt.Printf("{ %s }, { %v }, { %s }\n", strings.Join(val1, ", "), val2, strings.Join(val3, ", "))
 }

--- a/choose/choose.go
+++ b/choose/choose.go
@@ -54,6 +54,10 @@ func New(choices []Choice, opts ...Option) *Model {
 	return m
 }
 
+func (m Model) Index() int {
+	return m.cursor
+}
+
 func (m Model) Data() string {
 	return m.choices[m.cursor].Text
 }

--- a/choose/choose_test.go
+++ b/choose/choose_test.go
@@ -16,37 +16,37 @@ func TestChoose(t *testing.T) {
 	for _, testcase := range []struct {
 		model choose.Model
 		keys  []byte
-		data  string
+		index int
 	}{
 		{
 			model: *choose.NewWithStrings(items),
 			keys:  []byte("\r\n"),
-			data:  "Item 1",
+			index: 0,
 		},
 		{
 			model: *choose.NewWithStrings(items),
 			keys:  []byte("kkjjj\r\n"),
-			data:  "Item 2",
+			index: 1,
 		},
 		{
 			model: *choose.NewWithStrings(items),
 			keys:  []byte{'k', 'k', byte(tea.KeyTab), byte(tea.KeyTab), byte(tea.KeyTab), '\r', '\n'},
-			data:  "Item 2",
+			index: 1,
 		},
 		{
 			model: *choose.NewWithStrings(items, choose.WithKeyMap(choose.HorizontalKeyMap)),
 			keys:  []byte("\r\n"),
-			data:  "Item 1",
+			index: 0,
 		},
 		{
 			model: *choose.NewWithStrings(items, choose.WithKeyMap(choose.HorizontalKeyMap)),
 			keys:  []byte("hhlll\r\n"),
-			data:  "Item 2",
+			index: 1,
 		},
 		{
 			model: *choose.NewWithStrings(items, choose.WithKeyMap(choose.HorizontalKeyMap)),
 			keys:  []byte{'h', 'h', byte(tea.KeyTab), byte(tea.KeyTab), byte(tea.KeyTab), '\r', '\n'},
-			data:  "Item 2",
+			index: 1,
 		},
 	} {
 		var in bytes.Buffer
@@ -59,8 +59,9 @@ func TestChoose(t *testing.T) {
 		m, ok := tm.(choose.Model)
 		require.Equal(t, true, ok)
 
-		require.Equal(t, testcase.data, m.Data())
-		require.Equal(t, testcase.data, m.DataString())
+		require.Equal(t, testcase.index, m.Index())
+		require.Equal(t, items[testcase.index], m.Data())
+		require.Equal(t, items[testcase.index], m.DataString())
 		require.Equal(t, true, m.Quitting())
 	}
 }

--- a/multichoose/multichoose.go
+++ b/multichoose/multichoose.go
@@ -46,6 +46,17 @@ func New(choices []string, opts ...Option) *Model {
 	return m
 }
 
+func (m Model) Index() []int {
+	result := make([]int, 0)
+
+	for i := 0; i < len(m.choices); i++ {
+		if m.mc.IsSelected(i) {
+			result = append(result, i)
+		}
+	}
+	return result
+}
+
 func (m Model) Data() []string {
 	result := make([]string, 0)
 

--- a/multichoose/multichoose_test.go
+++ b/multichoose/multichoose_test.go
@@ -17,36 +17,43 @@ func TestMultiChoose(t *testing.T) {
 	for _, testcase := range []struct {
 		model multichoose.Model
 		keys  []byte
+		index []int
 		data  []string
 	}{
 		{
 			model: *multichoose.New(items),
 			keys:  []byte("\r\n"),
+			index: []int{},
 			data:  []string{},
 		},
 		{
 			model: *multichoose.New(items),
 			keys:  []byte("kk jj \r\n"),
+			index: []int{0, 1},
 			data:  []string{"Item 1", "Item 2"},
 		},
 		{
 			model: *multichoose.New(items),
 			keys:  []byte("kk  jj \r\n"),
+			index: []int{0},
 			data:  []string{"Item 1"},
 		},
 		{
 			model: *multichoose.New(items),
 			keys:  []byte("kk jj  \r\n"),
+			index: []int{1},
 			data:  []string{"Item 2"},
 		},
 		{
 			model: *multichoose.New(items),
 			keys:  []byte("kk  jj  \r\n"),
+			index: []int{},
 			data:  []string{},
 		},
 		{
 			model: *multichoose.New(items),
 			keys:  []byte{'k', 'k', ' ', byte(tea.KeyTab), byte(tea.KeyTab), ' ', '\r', '\n'},
+			index: []int{0, 1},
 			data:  []string{"Item 1", "Item 2"},
 		},
 	} {
@@ -60,6 +67,7 @@ func TestMultiChoose(t *testing.T) {
 		m, ok := tm.(multichoose.Model)
 		require.Equal(t, true, ok)
 
+		require.Equal(t, testcase.index, m.Index())
 		require.Equal(t, testcase.data, m.Data())
 		require.Equal(t, strings.Join(testcase.data, ", "), m.DataString())
 		require.Equal(t, true, m.Quitting())

--- a/runners.go
+++ b/runners.go
@@ -18,6 +18,17 @@ func (p Prompt) Choose(choices []string, opts ...choose.Option) (string, error) 
 	return m.(choose.Model).Data(), nil
 }
 
+// ChooseIndex lets the user choose one of the given choices.
+func (p Prompt) ChooseIndex(choices []string, opts ...choose.Option) (int, error) {
+	pm := choose.NewWithStrings(choices, opts...)
+
+	m, err := p.Run(*pm, append(p.teaProgramOpts, pm.TeaProgramOpts()...)...)
+	if err != nil {
+		return 0, err
+	}
+	return m.(choose.Model).Index(), nil
+}
+
 // Choose lets the user choose one of the given choices.
 func (p Prompt) AdvancedChoose(choices []choose.Choice, opts ...choose.Option) (string, error) {
 	pm := choose.New(choices, opts...)
@@ -29,6 +40,17 @@ func (p Prompt) AdvancedChoose(choices []choose.Choice, opts ...choose.Option) (
 	return m.(choose.Model).Data(), nil
 }
 
+// Choose lets the user choose one of the given choices.
+func (p Prompt) AdvancedChooseIndex(choices []choose.Choice, opts ...choose.Option) (int, error) {
+	pm := choose.New(choices, opts...)
+
+	m, err := p.Run(*pm, append(p.teaProgramOpts, pm.TeaProgramOpts()...)...)
+	if err != nil {
+		return 0, err
+	}
+	return m.(choose.Model).Index(), nil
+}
+
 // MultiChoose lets the user choose multiples from the given choices.
 func (p Prompt) MultiChoose(choices []string, opts ...multichoose.Option) ([]string, error) {
 	pm := multichoose.New(choices, opts...)
@@ -38,6 +60,17 @@ func (p Prompt) MultiChoose(choices []string, opts ...multichoose.Option) ([]str
 		return nil, err
 	}
 	return m.(multichoose.Model).Data(), nil
+}
+
+// MultiChooseIndex lets the user choose multiples from the given choices.
+func (p Prompt) MultiChooseIndex(choices []string, opts ...multichoose.Option) ([]int, error) {
+	pm := multichoose.New(choices, opts...)
+
+	m, err := p.Run(*pm, append(p.teaProgramOpts, pm.TeaProgramOpts()...)...)
+	if err != nil {
+		return nil, err
+	}
+	return m.(multichoose.Model).Index(), nil
 }
 
 // Input asks the user to enter a string.


### PR DESCRIPTION
Hi,

This PR adds variants of `Choose`, `AdvancedChoose` and `MultiChoose` that return the index of the selected choice(s) rather than the string value.

I've encountered a number of situations where I wanted to prompt a user to select from an existing slice of arbitrary Go values, dynamically transformed into prompt options. That initial transformation is easy enough, but things get awkward once an option is selected as only the prompt text is returned, requiring a string search of the generated options to find the index of the selected value.

The new methods remove the search step by returning the index, allowing the final result to be retrieved directly, e.g.:
```go
// Asks the user to select an element of vals, transformed into prompt options by fn.
func ChooseFrom[VS ~[]V, V any](ask string, vals VS, fn func(V) choose.Choice) (V, error) {
  opts := make([]choose.Choice, len(vals))
  for idx, val := range vals {
    opts[idx] = fn(val)
  }
  idx, err := prompt.New().Ask(ask).AdvancedChooseIndex(opts)
  if err != nil {
    var nop V
    return nop, err
  }
  return vals[idx], err
}
```
```go
type MyThing struct {
  Name string
  A, B int
}

var ts = []MyThing{
  {"First", 1, 2},
  {"Second", 3, 4},
  {"Third", 5, 6},
  {"Fourth", 7, 8},
  {"Fifth", 9, 10},
}

func main() {
  val, err := ChooseFrom("Pick a thing.", ts, func(v MyThing) choose.Choice {
    return choose.Choice{
      Text: v.Name,
      Note: fmt.Sprintf("A = %d, B = %d", v.A, v.B),
    }
  })
  if err != nil {
    panic(err)
  }
  fmt.Println(val)
}
```
![choosefrom](https://github.com/user-attachments/assets/ba8a852c-ca5b-4d8f-b2cf-003f2e30e20b)
